### PR TITLE
Fix The incorrect spaces in the env definitions

### DIFF
--- a/specs/environments/v85s/setEnv.sh
+++ b/specs/environments/v85s/setEnv.sh
@@ -5,4 +5,4 @@ export WAS_PORT="8879";
 export WAS_CONNTYPE="SOAP";
 export WAS_DEBUG="1";
 export WSADMIN_PATH="/opt/IBM/WebSphere/AppServer/profiles/Dmgr01/bin/wsadmin.sh";
-export WAS_APPPATH ="/var/tmp/";
+export WAS_APPPATH="/var/tmp/";

--- a/specs/environments/v85s/setEnv_Win.bat
+++ b/specs/environments/v85s/setEnv_Win.bat
@@ -5,4 +5,4 @@ set WAS_PORT=8879
 set WAS_CONNTYPE=SOAP
 set WAS_DEBUG=1
 set WSADMIN_PATH=/opt/IBM/WebSphere/AppServer/profiles/Dmgr01/bin/wsadmin.sh
-set WAS_APPPATH =C:\
+set WAS_APPPATH=C:\

--- a/specs/environments/v85s/systemtest.env
+++ b/specs/environments/v85s/systemtest.env
@@ -5,4 +5,4 @@ WAS_PORT="8879";
 WAS_CONNTYPE="SOAP";
 WAS_DEBUG="1";
 WSADMIN_PATH="/opt/IBM/WebSphere/AppServer/profiles/Dmgr01/bin/wsadmin.sh";
-WAS_APPPATH ="/var/tmp/";
+WAS_APPPATH="/var/tmp/";

--- a/specs/environments/v90s/setEnv.sh
+++ b/specs/environments/v90s/setEnv.sh
@@ -5,4 +5,4 @@ export WAS_PORT="8879";
 export WAS_CONNTYPE="SOAP";
 export WAS_DEBUG="1";
 export WSADMIN_PATH="/opt/IBM/WebSphere/AppServer/profiles/Dmgr01/bin/wsadmin.sh";
-export WAS_APPPATH ="/var/tmp/";
+export WAS_APPPATH="/var/tmp/";

--- a/specs/environments/v90s/setEnv_Win.bat
+++ b/specs/environments/v90s/setEnv_Win.bat
@@ -5,4 +5,4 @@ set WAS_PORT=8879
 set WAS_CONNTYPE=SOAP
 set WAS_DEBUG=1
 set WSADMIN_PATH=/opt/IBM/WebSphere/AppServer/profiles/Dmgr01/bin/wsadmin.sh
-set WAS_APPPATH =C:\
+set WAS_APPPATH=C:\

--- a/specs/environments/v90s/systemtest.env
+++ b/specs/environments/v90s/systemtest.env
@@ -5,4 +5,4 @@ WAS_PORT="8879";
 WAS_CONNTYPE="SOAP";
 WAS_DEBUG="1";
 WSADMIN_PATH="/opt/IBM/WebSphere/AppServer/profiles/Dmgr01/bin/wsadmin.sh";
-WAS_APPPATH ="/var/tmp/";
+WAS_APPPATH="/var/tmp/";


### PR DESCRIPTION
This fix need to be merged to master before running the tests on the Stand Alone Containers