### PR TITLE
Ignore tests for timeout=0 for 80nd version of WebSphere. 

### DIFF
--- a/specs/src/test/groovy/com/electriccloud/plugin/spec/StopApplicationServers.groovy
+++ b/specs/src/test/groovy/com/electriccloud/plugin/spec/StopApplicationServers.groovy
@@ -3,6 +3,7 @@ package com.electriccloud.plugin.spec
 import spock.lang.*
 import com.electriccloud.plugin.spec.PluginTestHelper
 import com.electriccloud.spec.SpockTestSupport
+import static org.junit.Assume.*
 
 @Unroll
 @Stepwise
@@ -332,6 +333,8 @@ class StopApplicationServers extends PluginTestHelper {
 
     @Unroll
     def 'StopApplicationServer - Negative: : #testCaseID.name #testCaseID.description'(){
+        assumeFalse(wasHost=='websphere80nd' && (testCaseID.name=='C363350' || testCaseID.name=='C363351'))
+
         if (startedServers){
             startApplicationServer(startedServers)
         }


### PR DESCRIPTION
Ignore tests for timeout=0 for 80nd version of WebSphere. In the 80 version those negative tests have positive results.